### PR TITLE
fix: type should match cjs format

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,4 +12,4 @@ type Runner<T extends Record<string, unknown>> = {
  */
 declare function runner<T extends Record<string, unknown>>(system: Systemic<T>, options?: { restart?: { window: string }; logger?: any }): Runner<T>;
 
-export default runner;
+export = runner;


### PR DESCRIPTION
Types are not correct, they are not aligned with the code.
Similar to https://github.com/onebeyond/systemic/pull/69

## Related Issue
Didn't open an issue, should I do it?

## Motivation and Context
This is an issue users encounter if they try to consume this module from an ESM service.

`export default runner` should be used if in the js file we were doing `export default runner;` -> the package is exported as a ES module.
When exporting a CJS module instead (like we're doing here with `module.exports = ...`) the type definition should be `export = runner;`

Typescript is probably clever enough to not raise any error when consuming this in a CJS service, but in an ESM environment it's raising an error, see screenshot 
<img width="1744" height="308" alt="image" src="https://github.com/user-attachments/assets/c5c0c529-ae3b-4ca5-93eb-f2c470ad7f66" />


## How Has This Been Tested?
This is a change only in the types, I've tried it changing the type definition directly in the node_modules both in a ESM service and in a CJS service

Working in CJS service
<img width="1744" height="308" alt="image" src="https://github.com/user-attachments/assets/53a256b4-8ba9-469e-a08f-d8bb647f5457" />

Working in ESM service
<img width="1744" height="308" alt="image" src="https://github.com/user-attachments/assets/7ef9c8a8-e5c7-42d6-8a0d-c0f10de5486d" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
