### PR TITLE
Release: 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "systemic-service-runner",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "parse-duration": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemic-service-runner",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Starts systemic systems",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Braking changes

- The project now reflects that is using a MIT licence (https://github.com/onebeyond/systemic-service-runner/pull/12)

## What's Changed
* Docs: Update license by @UlisesGascon in https://github.com/onebeyond/systemic-service-runner/pull/12
* fix: type should match cjs format by @albertodeago in https://github.com/onebeyond/systemic-service-runner/pull/13

## New Contributors
* @albertodeago made their first contribution in https://github.com/onebeyond/systemic-service-runner/pull/13

**Full Changelog**: https://github.com/onebeyond/systemic-service-runner/compare/v2.0.0...master